### PR TITLE
Fix Multiverse problem

### DIFF
--- a/src/main/java/io/github/addoncommunity/galactifun/Galactifun.java
+++ b/src/main/java/io/github/addoncommunity/galactifun/Galactifun.java
@@ -2,10 +2,17 @@ package io.github.addoncommunity.galactifun;
 
 import java.util.logging.Level;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import lombok.Getter;
 
 import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.generator.ChunkGenerator;
 
+import io.github.addoncommunity.galactifun.api.worlds.AlienWorld;
+import io.github.addoncommunity.galactifun.api.worlds.PlanetaryWorld;
 import io.github.addoncommunity.galactifun.base.BaseAlien;
 import io.github.addoncommunity.galactifun.base.BaseItems;
 import io.github.addoncommunity.galactifun.base.BaseMats;
@@ -100,6 +107,20 @@ public final class Galactifun extends AbstractAddon {
     public void load() {
         // Default to not logging world settings
         Bukkit.spigot().getConfig().set("world-settings.default.verbose", false);
+    }
+
+    @Nullable
+    @Override
+    public ChunkGenerator getDefaultWorldGenerator(@Nonnull String worldName, @Nullable String id) {
+        World world = Bukkit.getWorld(worldName);
+        if (world == null) return null;
+
+        PlanetaryWorld planetaryWorld = this.worldManager.getWorld(world);
+        if (planetaryWorld instanceof AlienWorld) {
+            return planetaryWorld.world().getGenerator();
+        }
+
+        return null;
     }
 
 }


### PR DESCRIPTION
## Changes
<!-- Please list all the changes you have made. -->
Fixes the Multiverse problem by allowing you to specify `-g Galactifun` when importing a planet

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break world generation, mob spawning, and the like.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
