### PR TITLE
check for player permission on rocket launch

### DIFF
--- a/src/main/java/io/github/addoncommunity/galactifun/api/items/Rocket.java
+++ b/src/main/java/io/github/addoncommunity/galactifun/api/items/Rocket.java
@@ -56,6 +56,8 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.core.handlers.BlockPlaceHandler;
 import io.github.thebusybiscuit.slimefun4.core.handlers.BlockUseHandler;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
 import io.github.thebusybiscuit.slimefun4.libraries.paperlib.PaperLib;
 import io.github.thebusybiscuit.slimefun4.utils.ChatUtils;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
@@ -233,6 +235,12 @@ public abstract class Rocket extends SlimefunItem {
 
             if (destBlock == null) {
                 destBlock = to.getBlockAt(x, to.getMaxHeight() - 4, z);
+            }
+
+            if (!Slimefun.getProtectionManager().hasPermission(p, destBlock, Interaction.PLACE_BLOCK)) {
+                p.sendMessage(ChatColor.RED + "Launch was not successful! You do not have permission to land there!");
+                BlockStorage.addBlockInfo(rocket, "isLaunching", "false");
+                return;
             }
 
             destBlock.setType(Material.CHEST);


### PR DESCRIPTION
## Changes
<!-- Please list all the changes you have made. -->
When the rocket tries to land, check for the player's permission and cancel the launch if they do not have permission to place there. 

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Related: #89 
Rockets can still be used when it is disabled, which is an issue not fixed by this PR.

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break world generation, mob spawning, and the like.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
