### PR TITLE
Change Ticking System

### DIFF
--- a/src/main/java/io/github/addoncommunity/galactifun/api/aliens/Alien.java
+++ b/src/main/java/io/github/addoncommunity/galactifun/api/aliens/Alien.java
@@ -64,6 +64,7 @@ public class Alien<T extends Mob> {
     public final T spawn(@Nonnull Location loc, @Nonnull World world) {
         T mob = world.spawn(loc, this.clazz);
 
+        this.alienManager.addUUID(mob.getUniqueId());
         PersistentDataAPI.setString(mob, this.alienManager.key(), this.id);
 
         Objects.requireNonNull(mob.getAttribute(Attribute.GENERIC_MAX_HEALTH)).setBaseValue(this.maxHealth);

--- a/src/main/java/io/github/addoncommunity/galactifun/core/managers/AlienManager.java
+++ b/src/main/java/io/github/addoncommunity/galactifun/core/managers/AlienManager.java
@@ -189,9 +189,7 @@ public final class AlienManager implements Listener {
             loadedChunks.put(world, chunks);
             for (Entity entity : chunk.getEntities()) {
                 UUID uuid = entity.getUniqueId();
-                if (alienSet.contains(uuid)) {
-                    continue;
-                }
+                if (alienSet.contains(uuid)) continue;
 
                 Alien<?> alien = getAlien(entity);
                 if (alien != null) {

--- a/src/main/java/io/github/addoncommunity/galactifun/core/managers/AlienManager.java
+++ b/src/main/java/io/github/addoncommunity/galactifun/core/managers/AlienManager.java
@@ -51,6 +51,7 @@ public final class AlienManager implements Listener {
     private final Set<UUID> alienSet = new HashSet<>();
 
     public AlienManager(Galactifun galactifun) {
+        findAliens();
         Events.registerListener(this);
         Scheduler.repeat(galactifun.getConfig().getInt("aliens.tick-interval", 1, 20), this::tick);
 
@@ -81,6 +82,17 @@ public final class AlienManager implements Listener {
         return Collections.unmodifiableCollection(this.aliens.values());
     }
 
+    public void findAliens() {
+        for (World world : Bukkit.getWorlds()) {
+            for (LivingEntity entity : world.getLivingEntities()) {
+                Alien<?> alien = getAlien(entity);
+                if (alien != null) {
+                    addUUID(entity.getUniqueId());
+                }
+            }
+        }
+    }
+
     public void addUUID(@Nonnull UUID uuid) {
         alienSet.add(uuid);
     }
@@ -91,9 +103,9 @@ public final class AlienManager implements Listener {
         }
 
         for (UUID uuid : alienSet) {
-            final Entity entity = Bukkit.getEntity(uuid);
+            Entity entity = Bukkit.getEntity(uuid);
             if (entity instanceof LivingEntity livingEntity) {
-                final Alien<?> alien = getAlien(entity);
+                Alien<?> alien = getAlien(entity);
                 if (alien != null) {
                     alien.onEntityTick(livingEntity);
                 }


### PR DESCRIPTION
## Changes
Instead of iterating through all of the entities on the Server with a heavy method such as world#getLivingEntities().
It will now cache the entities UUID when it spawns it in. Then in the Ticking method we retrieve all of the entities with Bukkit#getEntity(UUID). 

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break world generation, mob spawning, and the like.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
