### PR TITLE
New ticking system & Remove command

### DIFF
--- a/src/main/java/io/github/addoncommunity/galactifun/Galactifun.java
+++ b/src/main/java/io/github/addoncommunity/galactifun/Galactifun.java
@@ -21,6 +21,7 @@ import io.github.addoncommunity.galactifun.base.BaseItems;
 import io.github.addoncommunity.galactifun.base.BaseMats;
 import io.github.addoncommunity.galactifun.base.BaseUniverse;
 import io.github.addoncommunity.galactifun.core.CoreItemGroup;
+import io.github.addoncommunity.galactifun.core.commands.AlienRemoveCommand;
 import io.github.addoncommunity.galactifun.core.commands.AlienSpawnCommand;
 import io.github.addoncommunity.galactifun.core.commands.EffectsCommand;
 import io.github.addoncommunity.galactifun.core.commands.GalactiportCommand;
@@ -126,6 +127,7 @@ public final class Galactifun extends AbstractAddon {
         getAddonCommand()
                 .addSub(new GalactiportCommand())
                 .addSub(new AlienSpawnCommand())
+                .addSub(new AlienRemoveCommand())
                 .addSub(new StructureCommand(this))
                 .addSub(new SealedCommand())
                 .addSub(new EffectsCommand());

--- a/src/main/java/io/github/addoncommunity/galactifun/api/aliens/Alien.java
+++ b/src/main/java/io/github/addoncommunity/galactifun/api/aliens/Alien.java
@@ -64,6 +64,7 @@ public class Alien<T extends Mob> {
     public final T spawn(@Nonnull Location loc, @Nonnull World world) {
         T mob = world.spawn(loc, this.clazz);
 
+        this.alienManager.addUUID(mob.getUniqueId());
         PersistentDataAPI.setString(mob, this.alienManager.key(), this.id);
 
         Objects.requireNonNull(mob.getAttribute(Attribute.GENERIC_MAX_HEALTH)).setBaseValue(this.maxHealth);

--- a/src/main/java/io/github/addoncommunity/galactifun/api/aliens/Alien.java
+++ b/src/main/java/io/github/addoncommunity/galactifun/api/aliens/Alien.java
@@ -64,8 +64,8 @@ public class Alien<T extends Mob> {
     public final T spawn(@Nonnull Location loc, @Nonnull World world) {
         T mob = world.spawn(loc, this.clazz);
 
-        this.alienManager.addUUID(mob.getUniqueId());
         PersistentDataAPI.setString(mob, this.alienManager.key(), this.id);
+        this.alienManager.addAlien(mob.getUniqueId());
 
         Objects.requireNonNull(mob.getAttribute(Attribute.GENERIC_MAX_HEALTH)).setBaseValue(this.maxHealth);
         mob.setHealth(this.maxHealth);

--- a/src/main/java/io/github/addoncommunity/galactifun/core/commands/AlienRemoveCommand.java
+++ b/src/main/java/io/github/addoncommunity/galactifun/core/commands/AlienRemoveCommand.java
@@ -1,0 +1,63 @@
+package io.github.addoncommunity.galactifun.core.commands;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
+
+import javax.annotation.Nonnull;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+
+import io.github.addoncommunity.galactifun.Galactifun;
+import io.github.mooy1.infinitylib.commands.SubCommand;
+
+public class AlienRemoveCommand extends SubCommand {
+    public AlienRemoveCommand() {
+        super("remove", "Removes an alien based on uuid", true);
+    }
+
+    @Override
+    public void execute(@Nonnull CommandSender commandSender, @Nonnull String[] strings) {
+        if (!(commandSender instanceof Player p) || strings.length != 1) {
+            return;
+        }
+
+        if (strings[0].equalsIgnoreCase("all")) {
+            for (UUID uuid : new HashSet<>(Galactifun.alienManager().alienIds())) {
+                Entity entity = Bukkit.getEntity(uuid);
+                if (entity != null && Galactifun.alienManager().getAlien(entity) != null) {
+                    entity.remove();
+                }
+            }
+            return;
+        }
+
+        try {
+            UUID uuid = UUID.fromString(strings[0]);
+            Entity entity = Bukkit.getEntity(uuid);
+
+            if (entity == null || Galactifun.alienManager().getAlien(entity) == null) {
+                throw new IllegalArgumentException();
+            }
+
+            entity.remove();
+        } catch (IllegalArgumentException ignored) {
+            p.sendMessage(ChatColor.RED + "Invalid UUID!");
+        }
+    }
+
+    @Override
+    public void complete(@Nonnull CommandSender commandSender, @Nonnull String[] strings, @Nonnull List<String> ids) {
+        if (strings.length == 1) {
+            ids.add("all");
+            for (UUID uuid : new HashSet<>(Galactifun.alienManager().alienIds())) {
+                ids.add(uuid.toString());
+            }
+        }
+    }
+
+}

--- a/src/main/java/io/github/addoncommunity/galactifun/core/managers/AlienManager.java
+++ b/src/main/java/io/github/addoncommunity/galactifun/core/managers/AlienManager.java
@@ -110,8 +110,11 @@ public final class AlienManager implements Listener {
         return Collections.unmodifiableSet(this.alienIds);
     }
 
-    public void addUUID(@Nonnull UUID uuid) {
-        this.alienIds.add(uuid);
+    public void addAlien(@Nonnull UUID uuid) {
+        Entity entity = Bukkit.getEntity(uuid);
+        if (entity != null && getAlien(entity) != null) {
+            this.alienIds.add(uuid);
+        }
     }
 
     private void tick() {

--- a/src/main/java/io/github/addoncommunity/galactifun/core/managers/AlienManager.java
+++ b/src/main/java/io/github/addoncommunity/galactifun/core/managers/AlienManager.java
@@ -1,9 +1,14 @@
 package io.github.addoncommunity.galactifun.core.managers;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -12,7 +17,7 @@ import lombok.Getter;
 
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
-import org.bukkit.World;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Mob;
@@ -29,6 +34,7 @@ import org.bukkit.event.entity.ProjectileLaunchEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.projectiles.ProjectileSource;
 
+import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
 import io.github.addoncommunity.galactifun.Galactifun;
 import io.github.addoncommunity.galactifun.api.aliens.Alien;
 import io.github.addoncommunity.galactifun.api.aliens.BossAlien;
@@ -43,13 +49,37 @@ public final class AlienManager implements Listener {
     @Getter
     private final NamespacedKey bossKey;
     private final Map<String, Alien<?>> aliens = new HashMap<>();
+    private final Set<UUID> alienIds = new HashSet<>();
+    private final YamlConfiguration config;
 
     public AlienManager(Galactifun galactifun) {
         Events.registerListener(this);
         Scheduler.repeat(galactifun.getConfig().getInt("aliens.tick-interval", 1, 20), this::tick);
 
+        File configFile = new File("plugins/Galactifun", "uuids.yml");
+        this.config = new YamlConfiguration();
+
+        // Load the uuids
+        if (configFile.exists()) {
+            try {
+                this.config.load(configFile);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
+        // Save the config after startup
+        Scheduler.run(() -> {
+            try {
+                this.config.save(configFile);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        });
+
         this.key = Galactifun.createKey("alien");
         this.bossKey = Galactifun.createKey("boss_alien");
+        this.alienIds.addAll(this.config.getStringList("uuids").stream().map(UUID::fromString).toList());
     }
 
     public void register(Alien<?> alien) {
@@ -75,16 +105,26 @@ public final class AlienManager implements Listener {
         return Collections.unmodifiableCollection(this.aliens.values());
     }
 
+    @Nonnull
+    public Set<UUID> alienIds() {
+        return Collections.unmodifiableSet(this.alienIds);
+    }
+
+    public void addUUID(@Nonnull UUID uuid) {
+        this.alienIds.add(uuid);
+    }
+
     private void tick() {
         for (Alien<?> alien : this.aliens.values()) {
             alien.onUniqueTick();
         }
 
-        for (World world : Bukkit.getWorlds()) {
-            for (LivingEntity entity : world.getLivingEntities()) {
-                Alien<?> alien = getAlien(entity);
+        for (UUID uuid : this.alienIds) {
+            Entity entity = Bukkit.getEntity(uuid);
+            if (entity instanceof LivingEntity livingEntity) {
+                Alien<?> alien = getAlien(livingEntity);
                 if (alien != null) {
-                    alien.onEntityTick(entity);
+                    alien.onEntityTick(livingEntity);
                 }
             }
         }
@@ -161,12 +201,23 @@ public final class AlienManager implements Listener {
         }
     }
 
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
+    private void onAlienRemove(@Nonnull EntityRemoveFromWorldEvent e) {
+        this.alienIds.remove(e.getEntity().getUniqueId());
+    }
+
     public void onDisable() {
         this.aliens().forEach(a -> {
             if (a instanceof BossAlien<?> b) {
                 b.removeBossBars();
             }
         });
+        this.config.set("uuids", this.alienIds.stream().map(UUID::toString).toList());
+        try {
+            this.config.save(new File("plugins/Galactifun", "uuids.yml"));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
 }

--- a/src/main/resources/uuids.yml
+++ b/src/main/resources/uuids.yml
@@ -1,0 +1,2 @@
+# Saved Alien UUIDS
+uuids: []


### PR DESCRIPTION
## Changes
- Added AlienRemoveCommand.java & added it as a sub command, this command will allow an operator to remove any aliens based on uuid (tabcompleted), or simply all of the aliens by putting "all"
- Overhauled the Alien Ticking system (apart from unique tick)
     -  Added uuids.yml, a file for saving any alien uuids on shutdown, and loading them on startup
     - Added a new private static set called "alienIds", this contains uuids, all of the uuids of any existing entities that represent aliens
     - Instead of looping through every world and every living entity in that world it will now just loop through the alienIds set, call Bukkit#getEntity with that uuid, check if its a living entity and then check if its an alien (which should always be true unless operators manually mess with things)
     - added a couple new methods to AlienManager.java
         - AlienManager#alienIds, which returns an unmodifiable version of alienIds
         - AlienManager#addAlien, which will take one parameter, a UUID, and add it to the alienIds map, this method also tests that the uuid is of an alien entity
     - in Alien.java, in the onSpawn method it now calls addAlien with the spawned mobs uuid

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break world generation, mob spawning, and the like.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
