### PR TITLE
Add Displays for the Gas Canisters to the Slimefun Guide

### DIFF
--- a/src/main/java/io/github/addoncommunity/galactifun/api/universe/attributes/atmosphere/Gas.java
+++ b/src/main/java/io/github/addoncommunity/galactifun/api/universe/attributes/atmosphere/Gas.java
@@ -1,6 +1,7 @@
 package io.github.addoncommunity.galactifun.api.universe.attributes.atmosphere;
 
 import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 import io.github.addoncommunity.galactifun.api.universe.PlanetaryObject;
 import io.github.addoncommunity.galactifun.base.BaseUniverse;
@@ -66,14 +67,16 @@ public enum Gas {
     @Getter
     private final SlimefunItem slimefunItem;
 
-    Gas(String texture) {
+    Gas(@Nonnull String texture) {
         this(texture, CoreRecipeType.ATMOSPHERIC_HARVESTER);
     }
 
+    @ParametersAreNonnullByDefault
     Gas(String texture, RecipeType recipeType) {
         this(texture, recipeType, new ItemStack[9]);
     }
 
+    @ParametersAreNonnullByDefault
     Gas(String texture, RecipeType recipeType, ItemStack[] recipe) {
         this.item = new SlimefunItemStack(
                 "ATMOSPHERIC_GAS_" + this.name(),
@@ -111,6 +114,7 @@ public enum Gas {
         setRecipe(HYDROGEN, BaseUniverse.JUPITER);
     }
 
+    @ParametersAreNonnullByDefault
     private static void setRecipe(Gas gas, PlanetaryObject planetaryObject) {
         gas.slimefunItem().setRecipe(new ItemStack[] {
                 null, null, null,

--- a/src/main/java/io/github/addoncommunity/galactifun/api/universe/attributes/atmosphere/Gas.java
+++ b/src/main/java/io/github/addoncommunity/galactifun/api/universe/attributes/atmosphere/Gas.java
@@ -2,6 +2,10 @@ package io.github.addoncommunity.galactifun.api.universe.attributes.atmosphere;
 
 import javax.annotation.Nonnull;
 
+import io.github.addoncommunity.galactifun.api.universe.PlanetaryObject;
+import io.github.addoncommunity.galactifun.base.BaseUniverse;
+import io.github.addoncommunity.galactifun.core.CoreRecipeType;
+
 import lombok.Getter;
 
 import org.bukkit.inventory.ItemStack;
@@ -31,29 +35,36 @@ public enum Gas {
     METHANE("ea005531b6167a86fb09d6c0f3db60f2650162d0656c2908d07b377111d8f2a2"),
     HYDROCARBONS("725691372e0734bfb57bb03690490661a83f053a3488860df3436ce1caa24d11"),
     HYDROGEN("725691372e0734bfb57bb03690490661a83f053a3488860df3436ce1caa24d11"),
-    SULFUR("c7a1ece691ad28d17bbbcecb22270c85e1c9581485806264c676de67c272e2d0"),
-    AMMONIA("c7a1ece691ad28d17bbbcecb22270c85e1c9581485806264c676de67c272e2d0"),
+    AMMONIA("c7a1ece691ad28d17bbbcecb22270c85e1c9581485806264c676de67c272e2d0", CoreRecipeType.CHEMICAL_REACTOR, new ItemStack[] {
+            NITROGEN.item, HYDROGEN.item.asQuantity(3), null,
+            null, null, null,
+            null, null, null
+    }),
     OTHER;
 
     static {
         if (SlimefunItems.FREEZER_2.getItem() instanceof Freezer freezer) {
-            freezer.registerRecipe(10, Gas.NITROGEN.item(), SlimefunItems.REACTOR_COOLANT_CELL.asQuantity(4));
+            freezer.registerRecipe(10, NITROGEN.item(), SlimefunItems.REACTOR_COOLANT_CELL.asQuantity(4));
         }
+
         if (SlimefunItems.COMBUSTION_REACTOR.getItem() instanceof CombustionGenerator generator) {
-            generator.registerFuel(new MachineFuel(15, Gas.HYDROGEN.item()));
-            generator.registerFuel(new MachineFuel(20, Gas.SULFUR.item()));
-            generator.registerFuel(new MachineFuel(30, Gas.HYDROCARBONS.item()));
-            generator.registerFuel(new MachineFuel(70, Gas.AMMONIA.item()));
-            generator.registerFuel(new MachineFuel(200, Gas.METHANE.item()));
+            generator.registerFuel(new MachineFuel(15, HYDROGEN.item()));
+            generator.registerFuel(new MachineFuel(30, HYDROCARBONS.item()));
+            generator.registerFuel(new MachineFuel(70, AMMONIA.item()));
+            generator.registerFuel(new MachineFuel(200, METHANE.item()));
         }
+
         if (BaseItems.DIAMOND_ANVIL.getItem() instanceof DiamondAnvil anvil) {
-            anvil.registerRecipe(10, Gas.HYDROGEN.item().asQuantity(4), Gas.HELIUM.item());
-            anvil.registerRecipe(10, Gas.HELIUM.item().asQuantity(4), BaseMats.FUSION_PELLET);
+            anvil.registerRecipe(10, HYDROGEN.item().asQuantity(4), HELIUM.item());
+            anvil.registerRecipe(10, HELIUM.item().asQuantity(4), BaseMats.FUSION_PELLET);
         }
     }
 
     @Getter
     private final SlimefunItemStack item;
+
+    @Getter
+    private final SlimefunItem slimefunItem;
 
     Gas(String texture) {
         this.item = new SlimefunItemStack(
@@ -64,11 +75,13 @@ public enum Gas {
                 "&f&oTexture by Sefiraat"
         );
 
-        new SlimefunItem(CoreItemGroup.ITEMS, this.item, RecipeType.NULL, new ItemStack[9]).register(Galactifun.instance());
+        this.slimefunItem = new SlimefunItem(CoreItemGroup.ITEMS, this.item, recipeType, recipe);
+        this.slimefunItem.register(Galactifun.instance());
     }
 
     Gas() {
         this.item = null;
+        this.slimefunItem = null;
     }
 
 
@@ -78,4 +91,23 @@ public enum Gas {
         return ChatUtils.humanize(this.name());
     }
 
+    public static void setRecipes() {
+        setRecipe(OXYGEN, BaseUniverse.EARTH);
+        setRecipe(NITROGEN, BaseUniverse.EARTH);
+        setRecipe(CARBON_DIOXIDE, BaseUniverse.EARTH);
+        setRecipe(WATER, BaseUniverse.EARTH);
+        setRecipe(HELIUM, BaseUniverse.JUPITER);
+        setRecipe(ARGON, BaseUniverse.EARTH);
+        setRecipe(METHANE, BaseUniverse.SATURN);
+        setRecipe(HYDROCARBONS, BaseUniverse.TITAN);
+        setRecipe(HYDROGEN, BaseUniverse.JUPITER);
+    }
+
+    private static void setRecipe(Gas gas, PlanetaryObject planetaryObject) {
+        gas.slimefunItem().setRecipe(new ItemStack[] {
+                null, null, null,
+                null, planetaryObject.item(), null,
+                null, null, null
+        });
+    }
 }

--- a/src/main/java/io/github/addoncommunity/galactifun/api/universe/attributes/atmosphere/Gas.java
+++ b/src/main/java/io/github/addoncommunity/galactifun/api/universe/attributes/atmosphere/Gas.java
@@ -67,6 +67,14 @@ public enum Gas {
     private final SlimefunItem slimefunItem;
 
     Gas(String texture) {
+        this(texture, CoreRecipeType.ATMOSPHERIC_HARVESTER);
+    }
+
+    Gas(String texture, RecipeType recipeType) {
+        this(texture, recipeType, new ItemStack[9]);
+    }
+
+    Gas(String texture, RecipeType recipeType, ItemStack[] recipe) {
         this.item = new SlimefunItemStack(
                 "ATMOSPHERIC_GAS_" + this.name(),
                 SlimefunUtils.getCustomHead(texture),

--- a/src/main/java/io/github/addoncommunity/galactifun/base/BaseUniverse.java
+++ b/src/main/java/io/github/addoncommunity/galactifun/base/BaseUniverse.java
@@ -220,6 +220,8 @@ public final class BaseUniverse {
         TITAN.register(galactifun);
         MARS.register(galactifun);
         THE_MOON.register(galactifun);
+
+        Gas.setRecipes();
     }
 
 }

--- a/src/main/java/io/github/addoncommunity/galactifun/core/CoreRecipeType.java
+++ b/src/main/java/io/github/addoncommunity/galactifun/core/CoreRecipeType.java
@@ -1,5 +1,7 @@
 package io.github.addoncommunity.galactifun.core;
 
+import io.github.addoncommunity.galactifun.base.BaseItems;
+
 import lombok.experimental.UtilityClass;
 
 import org.bukkit.Material;
@@ -13,6 +15,8 @@ import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 public final class CoreRecipeType {
 
     public static final RecipeType ALIEN_DROP = new RecipeType(Galactifun.createKey("alien_drop"), RecipeType.MOB_DROP.toItem());
+    public static final RecipeType ATMOSPHERIC_HARVESTER = new RecipeType(Galactifun.createKey("atmospheric_harvester"), BaseItems.ATMOSPHERIC_HARVESTER);
+    public static final RecipeType CHEMICAL_REACTOR = new RecipeType(Galactifun.createKey("chemical_reactor"), BaseItems.CHEMICAL_REACTOR);
     public static final RecipeType WORLD_GEN = new RecipeType(Galactifun.createKey("world_gen"), new CustomItemStack(
             Material.END_STONE,
             "&fNaturally Generated",


### PR DESCRIPTION
## Changes
- Removed Sulfur Gas as it was not possible to get in survival.
- Adds 2 Recipe Types, 1 for the Atmospheric Harvester, the other for the Chemical Reactor
- Added Visuals for the Gas Canisters to the Guide:
![image](https://user-images.githubusercontent.com/65748158/230701570-eee922a3-7f64-4201-b9db-0d2bce496482.png)
![image](https://user-images.githubusercontent.com/65748158/230701582-dfa4c8b2-19d8-499e-8511-a228f12bb514.png)

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break world generation, mob spawning, and the like.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
