### PR TITLE
Galactic will Be Disable if the Plugin `ChatColor2` is Enabled.

### DIFF
--- a/src/main/java/io/github/addoncommunity/galactifun/Galactifun.java
+++ b/src/main/java/io/github/addoncommunity/galactifun/Galactifun.java
@@ -93,6 +93,12 @@ public final class Galactifun extends AbstractAddon {
                 shouldDisable = true;
             }
 
+            if (Bukkit.getPluginManager().isPluginEnabled("ChatColor2")) {
+                log(Level.SEVERE, "Galactifun will not work properly with ChatColor2");
+                log(Level.SEVERE, "Please disable ChatColor2");
+                shouldDisable = true;
+            }
+
             if (shouldDisable) {
                 Bukkit.getPluginManager().disablePlugin(this);
                 return;


### PR DESCRIPTION
Galactic will be disabled if the Plugin `ChatColor2` is Enabled.

Issue # 149

## Changes
<!-- Please list all the changes you have made. -->
In `Galactifun.java` (Main Class), I have added, when ChatColor2 is Present, Galactic will shut down, and show a error log.

## Related Issues
After Extensive Testing, The Plugin `ChatColor2` was just Causing the Chemical Rockets to Say `Launch Cancelled` Even After all the Proper Placement of Launch Pad Core, and Launch Pad Floors, even with Fuel in it.

I am not sure what in ChatColor2 was causing Galactic to say 'Launch Cancelled'.

- Slimefun Version: DEV 1061
- Server Version: Paper 1.19.4
- Galactic Version: DEV 75

## Checklist
- ✅ I have fully tested the proposed changes and promise that they will not break world generation, mob spawning, etc
- ✅ I followed the existing code standards and didn't mess up the formatting.
- ✅  I did my best to add documentation to any public classes or methods I added.
- ✅  I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behavior for null values


